### PR TITLE
Disabled rules were ignored because of string conversion

### DIFF
--- a/autoload/grammarous.vim
+++ b/autoload/grammarous.vim
@@ -280,7 +280,7 @@ function! s:invoke_check(range_start, ...)
     let cmdargs = printf(
             \   '-c %s -d %s -l %s --api %s',
             \   &fileencoding ? &fileencoding : &encoding,
-            \   string(join(get(g:grammarous#disabled_rules, &filetype, get(g:grammarous#disabled_rules, '*', [])), ',')),
+            \   join(get(g:grammarous#disabled_rules, &filetype, get(g:grammarous#disabled_rules, '*', [])), ','),
             \   lang,
             \   substitute(tmpfile, '\\\s\@!', '\\\\', 'g')
             \ )


### PR DESCRIPTION
Calling "string" on an array results in its elements being surrounded by single quotes. This behaviour on the array of disabled rules resulted in such quotes polluting the first and the last elements on the array, thus making them unrecognisable by LanguageTools parser.