### PR TITLE
Upgrade LanguageTool to 4.0

### DIFF
--- a/autoload/grammarous.vim
+++ b/autoload/grammarous.vim
@@ -11,7 +11,7 @@ let s:job_is_available = has('job') && has('patch-8.0.0027')
 
 let g:grammarous#root                            = fnamemodify(expand('<sfile>'), ':p:h:h')
 let g:grammarous#jar_dir                         = get(g:, 'grammarous#jar_dir', g:grammarous#root . '/misc')
-let g:grammarous#jar_url                         = get(g:, 'grammarous#jar_url', 'https://www.languagetool.org/download/LanguageTool-3.8.zip')
+let g:grammarous#jar_url                         = get(g:, 'grammarous#jar_url', 'https://www.languagetool.org/download/LanguageTool-4.0.zip')
 let g:grammarous#java_cmd                        = get(g:, 'grammarous#java_cmd', 'java')
 let g:grammarous#default_lang                    = get(g:, 'grammarous#default_lang', 'en')
 let g:grammarous#use_vim_spelllang               = get(g:, 'grammarous#use_vim_spelllang', 0)


### PR DESCRIPTION
Now runs with Java 9. It does not have compatibility issues.

Reference: https://forum.languagetool.org/t/announcement-languagetool-4-0/2464