### PR TITLE
Ignore auto-generated tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 misc
+doc/tags


### PR DESCRIPTION
`docs/tags` is generated automatically when Grammarous is run, thus it shouldn't be tracked in git.