### PR TITLE
Use LanguageTool-stable.zip

### DIFF
--- a/autoload/grammarous.vim
+++ b/autoload/grammarous.vim
@@ -12,7 +12,7 @@ let s:job_is_available = has('job') && has('patch-8.0.0027')
 let s:grammarous_root                            = fnamemodify(expand('<sfile>'), ':p:h:h')
 
 let g:grammarous#jar_dir                         = get(g:, 'grammarous#jar_dir', s:grammarous_root . '/misc')
-let g:grammarous#jar_url                         = get(g:, 'grammarous#jar_url', 'https://www.languagetool.org/download/LanguageTool-4.1.zip')
+let g:grammarous#jar_url                         = get(g:, 'grammarous#jar_url', 'https://www.languagetool.org/download/LanguageTool-stable.zip')
 let g:grammarous#java_cmd                        = get(g:, 'grammarous#java_cmd', 'java')
 let g:grammarous#default_lang                    = get(g:, 'grammarous#default_lang', 'en')
 let g:grammarous#use_vim_spelllang               = get(g:, 'grammarous#use_vim_spelllang', 0)


### PR DESCRIPTION
Track stable LanguageTool rather than hardcoding the version