### PR TITLE
Display all replacement suggestions from LanguageTool

### DIFF
--- a/autoload/grammarous/info_win.vim
+++ b/autoload/grammarous/info_win.vim
@@ -79,8 +79,8 @@ function! s:get_info_buffer(e)
     if a:e.replacements !=# ''
         let lines +=
         \ [
-        \   'Correction:',
-        \   '    ' . string(split(a:e.replacements, '#', 1)[0]),
+        \   'Corrections:',
+        \   '    ' . join(split(a:e.replacements, '#', 1), '; '),
         \   '',
         \ ]
     endif


### PR DESCRIPTION
This proposal relates to issue #86. It displays the replacements in the style of languagetool-commandline: separated by semicolons.

I'm wondering whether the list may break some logic in the info window, if it is too long and therefore occupies several lines.

Matthias