### PR TITLE
Convert byte offset to char, to fix wrong highlight in non ascii text

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ Please set `g:grammarous#show_first_error` to `1`. It opens an information windo
 Please set `g:grammarous#use_location_list` to `1`. It sets all grammatical errors to location list.
 This variable is set to `0` by default to avoid conflicts of location list usage with other plugins.
 
+### I want to highlight error by char count not byte
+
+Please set `g:grammarous#convert_char_to_byte` to `1`. This should fix wrong highlight in UTF-8 text.
+
 ## Automatic installation
 
 This plugin attempts to install [LanguageTool](https://www.languagetool.org/) using `curl` or `wget` command at first time.

--- a/README.md
+++ b/README.md
@@ -218,9 +218,6 @@ Please set `g:grammarous#show_first_error` to `1`. It opens an information windo
 Please set `g:grammarous#use_location_list` to `1`. It sets all grammatical errors to location list.
 This variable is set to `0` by default to avoid conflicts of location list usage with other plugins.
 
-### I want to highlight error by char count not byte
-
-Please set `g:grammarous#convert_char_to_byte` to `1`. This should fix wrong highlight in UTF-8 text.
 
 ## Automatic installation
 

--- a/autoload/grammarous.vim
+++ b/autoload/grammarous.vim
@@ -189,7 +189,7 @@ function! s:convert_char_to_byte(errs) abort
         let e.errorlength = len(strcharpart(line_from, e.fromx, e.errorlength))
         let e.fromx = byteidx(line_from, str2nr(e.fromx)) + 1
         let e.tox = byteidx(line_to, str2nr(e.tox))
-        if ch_from =~ '\(\s\|[`<>!@#$%^&*(){}\[\].,:;\"''\\/]\)'
+        if ch_from =~# '\(\s\|[`<>!@#$%^&*(){}\[\].,:;\"''\\/]\)'
             let e.fromx += 1
             if e.fromy == e.toy
                 let e.tox += 1

--- a/autoload/grammarous.vim
+++ b/autoload/grammarous.vim
@@ -187,8 +187,8 @@ function! s:convert_char_to_byte(errs) abort
         let line_to = getline(str2nr(e.toy) + 1)
         let ch_from = strcharpart(line_from, str2nr(e.fromx), 1)
         let e.errorlength = len(strcharpart(line_from, e.fromx, e.errorlength))
-        let e.fromx = len(strcharpart(line_from, 0, str2nr(e.fromx))) + 1
-        let e.tox = len(strcharpart(line_to, 0, str2nr(e.tox))) + 1
+        let e.fromx = len(strcharpart(line_from, 0, str2nr(e.fromx)))
+        let e.tox = len(strcharpart(line_to, 0, str2nr(e.tox)))
     endfor
 endfunction
 
@@ -223,7 +223,7 @@ function! s:set_errors_from_xml_string(xml) abort
     echomsg printf('Detected %d grammatical error%s', len, len > 1 ? 's' : '')
     call grammarous#highlight_errors_in_current_buffer(b:grammarous_result)
     if parsed['move-to-first-error']
-        call cursor(b:grammarous_result[0].fromy+1, b:grammarous_result[0].fromx)
+        call cursor(b:grammarous_result[0].fromy+1, b:grammarous_result[0].fromx+1)
     endif
 
     if g:grammarous#enable_spell_check
@@ -444,8 +444,8 @@ function! grammarous#highlight_errors_in_current_buffer(errs)
     if !g:grammarous#use_fallback_highlight
         for e in a:errs
             let e.id = s:highlight_error(
-                    \   [str2nr(e.fromy)+1, str2nr(e.fromx)],
-                    \   [str2nr(e.toy)+1, str2nr(e.tox)],
+                    \   [str2nr(e.fromy)+1, str2nr(e.fromx)+1],
+                    \   [str2nr(e.toy)+1, str2nr(e.tox)+1],
                     \   e.errorlength
                     \   )
         endfor
@@ -586,7 +586,7 @@ function! s:binary_search_by_pos(errors, the_pos, start, end)
     endif
 
     let m = (a:start + a:end) / 2
-    let from = [a:errors[m].fromy+1, a:errors[m].fromx]
+    let from = [a:errors[m].fromy+1, a:errors[m].fromx+1]
     let to = [a:errors[m].toy+1, a:errors[m].tox]
 
     if s:less_position(a:the_pos, from)
@@ -608,7 +608,7 @@ endfunction
 
 function! grammarous#fixit(err)
     if empty(a:err)
-     \ || !grammarous#move_to_checked_buf(a:err.fromy+1, a:err.fromx)
+     \ || !grammarous#move_to_checked_buf(a:err.fromy+1, a:err.fromx+1)
      \ || a:err.replacements ==# ''
         call grammarous#error('Cannot fix this error automatically.')
         return
@@ -800,7 +800,7 @@ endfunction
 
 function! grammarous#move_to_next_error(pos, errs)
     for e in a:errs
-        let p = [e.fromy+1, e.fromx]
+        let p = [e.fromy+1, e.fromx+1]
         if s:less_position(a:pos, p)
             return s:move_to_pos(p)
         endif
@@ -811,7 +811,7 @@ endfunction
 
 function! grammarous#move_to_previous_error(pos, errs)
     for e in reverse(copy(a:errs))
-        let p = [e.fromy+1, e.fromx]
+        let p = [e.fromy+1, e.fromx+1]
         if s:less_position(p, a:pos)
             return s:move_to_pos(p)
         endif

--- a/autoload/grammarous.vim
+++ b/autoload/grammarous.vim
@@ -183,12 +183,12 @@ endfunction
 
 function! s:convert_char_to_byte(errs) abort
     for e in a:errs
-        let line_from = getline(str2nr(e.fromy)+1)
-        let line_to = getline(str2nr(e.toy)+1)
+        let line_from = getline(str2nr(e.fromy) + 1)
+        let line_to = getline(str2nr(e.toy) + 1)
         let ch_from = strcharpart(line_from, e.fromx, 1)
         let e.errorlength = len(strcharpart(line_from, e.fromx, e.errorlength))
-        let e.fromx = byteidx(line_from,str2nr(e.fromx))+1
-        let e.tox = byteidx(line_to,str2nr(e.tox))
+        let e.fromx = byteidx(line_from, str2nr(e.fromx)) + 1
+        let e.tox = byteidx(line_to, str2nr(e.tox))
         if ch_from =~ '\(\s\|[`<>!@#$%^&*(){}\[\].,:;\"''\\/]\)'
             let e.fromx += 1
             if e.fromy == e.toy

--- a/autoload/grammarous.vim
+++ b/autoload/grammarous.vim
@@ -185,16 +185,10 @@ function! s:convert_char_to_byte(errs) abort
     for e in a:errs
         let line_from = getline(str2nr(e.fromy) + 1)
         let line_to = getline(str2nr(e.toy) + 1)
-        let ch_from = strcharpart(line_from, e.fromx, 1)
+        let ch_from = strcharpart(line_from, str2nr(e.fromx), 1)
         let e.errorlength = len(strcharpart(line_from, e.fromx, e.errorlength))
-        let e.fromx = byteidx(line_from, str2nr(e.fromx)) + 1
-        let e.tox = byteidx(line_to, str2nr(e.tox))
-        if ch_from =~# '\(\s\|[`<>!@#$%^&*(){}\[\].,:;\"''\\/]\)'
-            let e.fromx += 1
-            if e.fromy == e.toy
-                let e.tox += 1
-            endif
-        endif
+        let e.fromx = len(strcharpart(line_from, 0, str2nr(e.fromx))) + 1
+        let e.tox = len(strcharpart(line_to, 0, str2nr(e.tox))) + 1
     endfor
 endfunction
 

--- a/autoload/grammarous.vim
+++ b/autoload/grammarous.vim
@@ -353,7 +353,7 @@ function! s:invoke_check(range_start, ...)
     if g:grammarous#languagetool_cmd !=# ''
         let cmd = printf('%s %s', g:grammarous#languagetool_cmd, cmdargs)
     else
-        let cmd = printf('%s -jar %s %s', g:grammarous#java_cmd, substitute(jar, '\\\s\@!', '\\\\', 'g'), cmdargs)
+        let cmd = printf('%s -jar %s --line-by-line %s', g:grammarous#java_cmd, substitute(jar, '\\\s\@!', '\\\\', 'g'), cmdargs)
     endif
 
     if s:job_is_available

--- a/autoload/grammarous.vim
+++ b/autoload/grammarous.vim
@@ -30,7 +30,7 @@ let g:grammarous#hooks                           = get(g:, 'grammarous#hooks', {
 let g:grammarous#languagetool_cmd                = get(g:, 'grammarous#languagetool_cmd', '')
 let g:grammarous#show_first_error                = get(g:, 'grammarous#show_first_error', 0)
 let g:grammarous#use_location_list               = get(g:, 'grammarous#use_location_list', 0)
-let g:grammarous#convert_char_to_byte            = get(g:, 'grammarous#convert_char_to_byte', 0)
+let g:grammarous#convert_char_to_byte            = get(g:, 'grammarous#convert_char_to_byte', 1)
 
 highlight default link GrammarousError SpellBad
 highlight default link GrammarousInfoError ErrorMsg

--- a/autoload/grammarous/info_win.vim
+++ b/autoload/grammarous/info_win.vim
@@ -2,7 +2,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! grammarous#info_win#action_return()
-    call grammarous#move_to_checked_buf(b:grammarous_preview_error.fromy+1, b:grammarous_preview_error.fromx)
+    call grammarous#move_to_checked_buf(b:grammarous_preview_error.fromy+1, b:grammarous_preview_error.fromx+1)
 endfunction
 
 function! grammarous#info_win#action_fixit()
@@ -13,7 +13,7 @@ function! grammarous#info_win#action_remove_error()
     let e = b:grammarous_preview_error
     if !grammarous#move_to_checked_buf(
         \ b:grammarous_preview_error.fromy+1,
-        \ b:grammarous_preview_error.fromx )
+        \ b:grammarous_preview_error.fromx+1 )
         return
     endif
 
@@ -24,7 +24,7 @@ function! grammarous#info_win#action_disable_rule()
     let e = b:grammarous_preview_error
     if !grammarous#move_to_checked_buf(
         \ b:grammarous_preview_error.fromy+1,
-        \ b:grammarous_preview_error.fromx )
+        \ b:grammarous_preview_error.fromx+1 )
         return
     endif
 
@@ -34,7 +34,7 @@ endfunction
 function! grammarous#info_win#action_next_error()
     if !grammarous#move_to_checked_buf(
         \ b:grammarous_preview_error.fromy+1,
-        \ b:grammarous_preview_error.fromx )
+        \ b:grammarous_preview_error.fromx+1 )
         return
     endif
 
@@ -46,7 +46,7 @@ endfunction
 function! grammarous#info_win#action_previous_error()
     if !grammarous#move_to_checked_buf(
         \ b:grammarous_preview_error.fromy+1,
-        \ b:grammarous_preview_error.fromx )
+        \ b:grammarous_preview_error.fromx+1 )
         return
     endif
 

--- a/autoload/grammarous/info_win.vim
+++ b/autoload/grammarous/info_win.vim
@@ -2,7 +2,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! grammarous#info_win#action_return()
-    call grammarous#move_to_checked_buf(b:grammarous_preview_error.fromy+1, b:grammarous_preview_error.fromx+1)
+    call grammarous#move_to_checked_buf(b:grammarous_preview_error.fromy+1, b:grammarous_preview_error.fromx)
 endfunction
 
 function! grammarous#info_win#action_fixit()
@@ -13,7 +13,7 @@ function! grammarous#info_win#action_remove_error()
     let e = b:grammarous_preview_error
     if !grammarous#move_to_checked_buf(
         \ b:grammarous_preview_error.fromy+1,
-        \ b:grammarous_preview_error.fromx+1 )
+        \ b:grammarous_preview_error.fromx )
         return
     endif
 
@@ -24,7 +24,7 @@ function! grammarous#info_win#action_disable_rule()
     let e = b:grammarous_preview_error
     if !grammarous#move_to_checked_buf(
         \ b:grammarous_preview_error.fromy+1,
-        \ b:grammarous_preview_error.fromx+1 )
+        \ b:grammarous_preview_error.fromx )
         return
     endif
 
@@ -34,7 +34,7 @@ endfunction
 function! grammarous#info_win#action_next_error()
     if !grammarous#move_to_checked_buf(
         \ b:grammarous_preview_error.fromy+1,
-        \ b:grammarous_preview_error.fromx+1 )
+        \ b:grammarous_preview_error.fromx )
         return
     endif
 
@@ -46,7 +46,7 @@ endfunction
 function! grammarous#info_win#action_previous_error()
     if !grammarous#move_to_checked_buf(
         \ b:grammarous_preview_error.fromy+1,
-        \ b:grammarous_preview_error.fromx+1 )
+        \ b:grammarous_preview_error.fromx )
         return
     endif
 


### PR DESCRIPTION
This PR contains code for fixing wrong highlight due to that vim works with bytes not chars. Should fix #61.

Must say that `byteidx` method in vim sometimes return not exact result, so I used some hacks to shift highlight in right position.

I did't test it with multyline highlight, because couldn't emulate such grammatic error.

This feature disabled by default, to enable it you need to set `g:grammarous#convert_char_to_byte` to `1`.
