### PR TITLE
Add support for custom rule files

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ For example, below setting enables `PASSIVE_VOICE` rule in all filetypes.
 let g:grammarous#enabled_rules = {'*' : ['PASSIVE_VOICE']}
 ```
 
+### How can I pass my own rules file?
+
+Please use `g:grammarous#custom_rules` to pass the name of a file.
+
+For example, to set `path/to/config/data/languagetool/rules.xml` as the rulefile.
+
+```vim 
+let config_path = stdpath('config')
+let g:grammarous#custom_rules = config_path . '/data/languagetool/rules.xml'
+```
+
 ### Some rules annoy me.
 
 Please use `g:grammarous#disabled_rules` to disable specific rules.

--- a/autoload/grammarous.vim
+++ b/autoload/grammarous.vim
@@ -21,6 +21,7 @@ let g:grammarous#info_win_direction              = get(g:, 'grammarous#info_win_
 let g:grammarous#use_fallback_highlight          = get(g:, 'grammarous#use_fallback_highlight', !exists('*matchaddpos'))
 let g:grammarous#enabled_rules                   = get(g:, 'grammarous#enabled_rules', {})
 let g:grammarous#disabled_rules                  = get(g:, 'grammarous#disabled_rules', {'*' : ['WHITESPACE_RULE', 'EN_QUOTES']})
+let g:grammarous#custom_rules                    = get(g:, 'grammarous#custom_rules', "")
 let g:grammarous#enabled_categories              = get(g:, 'grammarous#enabled_categories', {})
 let g:grammarous#disabled_categories             = get(g:, 'grammarous#disabled_categories', {})
 let g:grammarous#default_comments_only_filetypes = get(g:, 'grammarous#default_comments_only_filetypes', {'*' : 0})
@@ -304,6 +305,16 @@ function! s:invoke_check(range_start, ...)
             \   lang,
             \   substitute(tmpfile, '\\\s\@!', '\\\\', 'g')
             \ )
+
+    if g:grammarous#custom_rules !=# ''
+        let custom_rules = printf("%s", substitute(g:grammarous#custom_rules, ' ', '\\ ', 'g'))
+        if !filereadable(g:grammarous#custom_rules)
+            call grammarous#error("Custom rules file '%s' does not exist or is not readable", g:grammarous#custom_rules)
+            return
+        else
+            let cmdargs = '--rulefile ' . custom_rules . ' ' . cmdargs
+        endif
+    endif    
 
     let disabled_rules = get(g:grammarous#disabled_rules, &filetype, get(g:grammarous#disabled_rules, '*', []))
     if !empty(disabled_rules)


### PR DESCRIPTION
The CLI of languagetool offers a `--rulefile` flag to pass in a `.xml` file of rules. I have added a simple addition of it.

- Updates README.md with details on how to use the option
- Adds a `g:grammarous#custom_rules` variable
- add `--rulefile ...` to `cmdargs`
- checks the provided file exists and replaces all `' '` with `'\ '`

Tested to work with installed jar and preexisting cmd (only tested with [languagetool](https://archlinux.org/packages/extra/any/languagetool/) packaged for Arch Linux, and on an Arch system). Tested to work with spaces.